### PR TITLE
Add React profile components

### DIFF
--- a/my-react-app/package.json
+++ b/my-react-app/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "recharts": "^2.9.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.29.0",

--- a/my-react-app/src/App.jsx
+++ b/my-react-app/src/App.jsx
@@ -1,35 +1,9 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
+import UserProfile from './components/UserProfile.jsx';
 
-function App() {
-  const [count, setCount] = useState(0)
-
+export default function App() {
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
-  )
+    <div>
+      <UserProfile />
+    </div>
+  );
 }
-
-export default App

--- a/my-react-app/src/components/ActivityChart.jsx
+++ b/my-react-app/src/components/ActivityChart.jsx
@@ -1,0 +1,17 @@
+import { ResponsiveContainer, BarChart, CartesianGrid, XAxis, YAxis, Tooltip, Bar } from 'recharts';
+
+export default function ActivityChart({ data }) {
+  if (!data) return null;
+  return (
+    <ResponsiveContainer width="100%" height={200}>
+      <BarChart data={data.sessions} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
+        <CartesianGrid strokeDasharray="3 3" />
+        <XAxis dataKey="day" tickLine={false} />
+        <YAxis orientation="right" tickLine={false} axisLine={false} />
+        <Tooltip />
+        <Bar dataKey="kilogram" fill="#282D30" radius={[5, 5, 0, 0]} barSize={7} />
+        <Bar dataKey="calories" fill="#E60000" radius={[5, 5, 0, 0]} barSize={7} />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/my-react-app/src/components/AverageSessionsChart.jsx
+++ b/my-react-app/src/components/AverageSessionsChart.jsx
@@ -1,0 +1,14 @@
+import { ResponsiveContainer, LineChart, Line, XAxis, Tooltip } from 'recharts';
+
+export default function AverageSessionsChart({ data }) {
+  if (!data) return null;
+  return (
+    <ResponsiveContainer width="100%" height={200}>
+      <LineChart data={data.sessions} margin={{ top: 20, right: 20, left: 20, bottom: 5 }}>
+        <XAxis dataKey="day" tickLine={false} axisLine={false} />
+        <Tooltip />
+        <Line type="monotone" dataKey="sessionLength" stroke="#fff" dot={false} />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}

--- a/my-react-app/src/components/Header.jsx
+++ b/my-react-app/src/components/Header.jsx
@@ -1,0 +1,7 @@
+export default function Header() {
+  return (
+    <header style={{ padding: '1rem', background: '#222', color: '#fff' }}>
+      <h1>SportSee</h1>
+    </header>
+  );
+}

--- a/my-react-app/src/components/KeyDataCard.jsx
+++ b/my-react-app/src/components/KeyDataCard.jsx
@@ -1,0 +1,8 @@
+export default function KeyDataCard({ label, value }) {
+  return (
+    <div style={{ border: '1px solid #eee', padding: '1rem', margin: '0.5rem' }}>
+      <strong>{value}</strong>
+      <p>{label}</p>
+    </div>
+  );
+}

--- a/my-react-app/src/components/PerformanceRadarChart.jsx
+++ b/my-react-app/src/components/PerformanceRadarChart.jsx
@@ -1,0 +1,16 @@
+import { ResponsiveContainer, RadarChart, PolarGrid, PolarAngleAxis, Radar } from 'recharts';
+
+export default function PerformanceRadarChart({ data }) {
+  if (!data) return null;
+  const kindMap = data.kind;
+  const chartData = data.data.map((d) => ({ ...d, kind: kindMap[d.kind] }));
+  return (
+    <ResponsiveContainer width="100%" height={250}>
+      <RadarChart data={chartData} outerRadius="70%">
+        <PolarGrid />
+        <PolarAngleAxis dataKey="kind" tick={{ fill: '#fff', fontSize: 12 }} />
+        <Radar dataKey="value" stroke="#ff0101" fill="#ff0101" fillOpacity={0.7} />
+      </RadarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/my-react-app/src/components/ScoreRadialChart.jsx
+++ b/my-react-app/src/components/ScoreRadialChart.jsx
@@ -1,0 +1,30 @@
+import { ResponsiveContainer, RadialBarChart, RadialBar } from 'recharts';
+
+export default function ScoreRadialChart({ value }) {
+  if (value == null) return null;
+  const percent = value * 100;
+  const data = [{ name: 'score', value: percent, fill: '#ff0000' }];
+
+  return (
+    <ResponsiveContainer width="100%" height={250}>
+      <RadialBarChart
+        innerRadius="80%"
+        outerRadius="100%"
+        data={data}
+        startAngle={90}
+        endAngle={450}
+      >
+        <RadialBar
+          minAngle={15}
+          background
+          clockWise
+          dataKey="value"
+        />
+      </RadialBarChart>
+      <div style={{ position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%, -50%)' }}>
+        <strong>{percent}%</strong>
+        <p>de votre objectif</p>
+      </div>
+    </ResponsiveContainer>
+  );
+}

--- a/my-react-app/src/components/UserProfile.jsx
+++ b/my-react-app/src/components/UserProfile.jsx
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react';
+import Header from './Header.jsx';
+import ActivityChart from './ActivityChart.jsx';
+import AverageSessionsChart from './AverageSessionsChart.jsx';
+import PerformanceRadarChart from './PerformanceRadarChart.jsx';
+import ScoreRadialChart from './ScoreRadialChart.jsx';
+import KeyDataCard from './KeyDataCard.jsx';
+import {
+  getUserMainData,
+  getUserActivity,
+  getUserAverageSessions,
+  getUserPerformance,
+} from '../services/userService.js';
+
+export default function UserProfile() {
+  const userId = 12;
+  const [mainData, setMainData] = useState(null);
+  const [activity, setActivity] = useState(null);
+  const [average, setAverage] = useState(null);
+  const [performance, setPerformance] = useState(null);
+
+  useEffect(() => {
+    getUserMainData(userId).then(setMainData);
+    getUserActivity(userId).then(setActivity);
+    getUserAverageSessions(userId).then(setAverage);
+    getUserPerformance(userId).then(setPerformance);
+  }, []);
+
+  const score = mainData?.todayScore ?? mainData?.score ?? 0;
+
+  return (
+    <div>
+      <Header />
+      <h2>{mainData?.userInfos?.firstName}</h2>
+      <div style={{ display: 'flex', flexWrap: 'wrap' }}>
+        <div style={{ flex: '1 1 60%', minWidth: 300 }}>
+          <ActivityChart data={activity} />
+          <AverageSessionsChart data={average} />
+          <PerformanceRadarChart data={performance} />
+          <ScoreRadialChart value={score} />
+        </div>
+        <div style={{ flex: '1 1 30%', minWidth: 200 }}>
+          {mainData &&
+            Object.entries(mainData.keyData || {}).map(([label, value]) => (
+              <KeyDataCard key={label} label={label} value={value} />
+            ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/my-react-app/src/services/userService.js
+++ b/my-react-app/src/services/userService.js
@@ -1,0 +1,25 @@
+const API_URL = 'http://localhost:3000/user';
+
+export async function getUserMainData(id) {
+  const res = await fetch(`${API_URL}/${id}`);
+  const json = await res.json();
+  return json.data;
+}
+
+export async function getUserActivity(id) {
+  const res = await fetch(`${API_URL}/${id}/activity`);
+  const json = await res.json();
+  return json.data;
+}
+
+export async function getUserAverageSessions(id) {
+  const res = await fetch(`${API_URL}/${id}/average-sessions`);
+  const json = await res.json();
+  return json.data;
+}
+
+export async function getUserPerformance(id) {
+  const res = await fetch(`${API_URL}/${id}/performance`);
+  const json = await res.json();
+  return json.data;
+}


### PR DESCRIPTION
## Summary
- add user service helpers for API data
- create chart components using Recharts
- add basic header and data card components
- build UserProfile page that fetches and displays all charts
- simplify App to render UserProfile
- add Recharts dependency

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6867a2c85afc8331a58032c8baa67d9a