### PR TITLE
Use env variable for API URL

### DIFF
--- a/my-react-app/.env
+++ b/my-react-app/.env
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:3000/user

--- a/my-react-app/README.md
+++ b/my-react-app/README.md
@@ -10,3 +10,13 @@ Currently, two official plugins are available:
 ## Expanding the ESLint configuration
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+
+## Environment variables
+
+Create a `.env` file in the project root to configure the API endpoint used by the application:
+
+```env
+VITE_API_URL=http://localhost:3000/user
+```
+
+`src/services/userService.js` reads this value using `import.meta.env.VITE_API_URL` when performing network requests.

--- a/my-react-app/src/services/userService.js
+++ b/my-react-app/src/services/userService.js
@@ -1,4 +1,5 @@
-const API_URL = 'http://localhost:3000/user';
+// Base URL for API requests comes from the Vite environment variable
+const API_URL = import.meta.env.VITE_API_URL;
 
 export async function getUserMainData(id) {
   const res = await fetch(`${API_URL}/${id}`);


### PR DESCRIPTION
## Summary
- add `.env` with `VITE_API_URL`
- read `VITE_API_URL` via `import.meta.env` in `userService`
- document the environment variable in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_687137908948833184b647ff72409dcf