### PR TITLE
Move score label outside chart

### DIFF
--- a/my-react-app/src/components/ScoreRadialChart.jsx
+++ b/my-react-app/src/components/ScoreRadialChart.jsx
@@ -6,25 +6,27 @@ export default function ScoreRadialChart({ value }) {
   const data = [{ name: 'score', value: percent, fill: '#ff0000' }];
 
   return (
-    <ResponsiveContainer width="100%" height={250}>
-      <RadialBarChart
-        innerRadius="80%"
-        outerRadius="100%"
-        data={data}
-        startAngle={90}
-        endAngle={450}
-      >
-        <RadialBar
-          minAngle={15}
-          background
-          clockWise
-          dataKey="value"
-        />
-      </RadialBarChart>
-      <div style={{ position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%, -50%)' }}>
+    <div className="score-chart-container">
+      <ResponsiveContainer width="100%" height="100%">
+        <RadialBarChart
+          innerRadius="80%"
+          outerRadius="100%"
+          data={data}
+          startAngle={90}
+          endAngle={450}
+        >
+          <RadialBar
+            minAngle={15}
+            background
+            clockWise
+            dataKey="value"
+          />
+        </RadialBarChart>
+      </ResponsiveContainer>
+      <div className="score-chart-label">
         <strong>{percent}%</strong>
         <p>de votre objectif</p>
       </div>
-    </ResponsiveContainer>
+    </div>
   );
 }

--- a/my-react-app/src/index.css
+++ b/my-react-app/src/index.css
@@ -66,3 +66,17 @@ button:focus-visible {
     background-color: #f9f9f9;
   }
 }
+
+.score-chart-container {
+  position: relative;
+  width: 100%;
+  height: 250px;
+}
+
+.score-chart-label {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- overlay radial chart label with absolute positioning
- apply new CSS classes for the score chart

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6871378fdb348331ac59178d5c4783d3