### PR TITLE
Add icon mapping for nutrient cards

### DIFF
--- a/my-react-app/src/components/KeyDataCard.jsx
+++ b/my-react-app/src/components/KeyDataCard.jsx
@@ -1,8 +1,56 @@
-export default function KeyDataCard({ label, value }) {
+// Mapping between nutritional keys and their display information.
+// The icons are simple emojis so the component works without any
+// additional dependencies or assets.
+export const KEY_INFO = {
+  calorieCount: {
+    label: 'Calories',
+    unit: 'kCal',
+    icon: '🔥',
+  },
+  proteinCount: {
+    label: 'Protéines',
+    unit: 'g',
+    icon: '🥚',
+  },
+  carbohydrateCount: {
+    label: 'Glucides',
+    unit: 'g',
+    icon: '🍞',
+  },
+  lipidCount: {
+    label: 'Lipides',
+    unit: 'g',
+    icon: '🧈',
+  },
+};
+
+/**
+ * Display a user key nutritional data card.
+ *
+ * @param {object} props
+ * @param {string} props.label - Human friendly label
+ * @param {number|string} props.value - Value to display
+ * @param {string} [props.unit] - Unit appended to the value
+ * @param {string} [props.icon] - Icon representing the data
+ */
+export default function KeyDataCard({ label, value, unit, icon }) {
   return (
-    <div style={{ border: '1px solid #eee', padding: '1rem', margin: '0.5rem' }}>
-      <strong>{value}</strong>
-      <p>{label}</p>
+    <div
+      style={{
+        border: '1px solid #eee',
+        padding: '1rem',
+        margin: '0.5rem',
+        display: 'flex',
+        alignItems: 'center',
+      }}
+    >
+      <span style={{ fontSize: '2rem', marginRight: '1rem' }}>{icon}</span>
+      <div>
+        <strong>{value}
+          {unit}
+        </strong>
+        <p>{label}</p>
+      </div>
     </div>
   );
 }

--- a/my-react-app/src/components/UserProfile.jsx
+++ b/my-react-app/src/components/UserProfile.jsx
@@ -4,7 +4,7 @@ import ActivityChart from './ActivityChart.jsx';
 import AverageSessionsChart from './AverageSessionsChart.jsx';
 import PerformanceRadarChart from './PerformanceRadarChart.jsx';
 import ScoreRadialChart from './ScoreRadialChart.jsx';
-import KeyDataCard from './KeyDataCard.jsx';
+import KeyDataCard, { KEY_INFO } from './KeyDataCard.jsx';
 import {
   getUserMainData,
   getUserActivity,
@@ -41,9 +41,18 @@ export default function UserProfile() {
         </div>
         <div style={{ flex: '1 1 30%', minWidth: 200 }}>
           {mainData &&
-            Object.entries(mainData.keyData || {}).map(([label, value]) => (
-              <KeyDataCard key={label} label={label} value={value} />
-            ))}
+            Object.entries(mainData.keyData || {}).map(([key, value]) => {
+              const info = KEY_INFO[key] || { label: key, unit: '', icon: '' };
+              return (
+                <KeyDataCard
+                  key={key}
+                  label={info.label}
+                  value={value}
+                  unit={info.unit}
+                  icon={info.icon}
+                />
+              );
+            })}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- map key data names to icons, labels and units
- show those details in `KeyDataCard`
- use mapping in `UserProfile` for each key data card

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6871378f78cc8331afd293e1770413de