### PR TITLE
Show user greeting in header

### DIFF
--- a/my-react-app/src/components/Header.jsx
+++ b/my-react-app/src/components/Header.jsx
@@ -1,7 +1,9 @@
-export default function Header() {
+export default function Header({ firstName }) {
   return (
     <header style={{ padding: '1rem', background: '#222', color: '#fff' }}>
       <h1>SportSee</h1>
+      <h2>Bonjour {firstName}</h2>
+      <p>Félicitation ! Vous avez explosé vos objectifs hier 👏</p>
     </header>
   );
 }

--- a/my-react-app/src/components/UserProfile.jsx
+++ b/my-react-app/src/components/UserProfile.jsx
@@ -30,8 +30,7 @@ export default function UserProfile() {
 
   return (
     <div>
-      <Header />
-      <h2>{mainData?.userInfos?.firstName}</h2>
+      <Header firstName={mainData?.userInfos?.firstName} />
       <div style={{ display: 'flex', flexWrap: 'wrap' }}>
         <div style={{ flex: '1 1 60%', minWidth: 300 }}>
           <ActivityChart data={activity} />


### PR DESCRIPTION
## Summary
- add personalized greeting to header
- pass user's first name from `UserProfile`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_6871378f71b48331b5ef40fc1f09eab8