### PR TITLE
Handle fetch errors in user service

### DIFF
--- a/my-react-app/src/components/UserProfile.jsx
+++ b/my-react-app/src/components/UserProfile.jsx
@@ -18,15 +18,38 @@ export default function UserProfile() {
   const [activity, setActivity] = useState(null);
   const [average, setAverage] = useState(null);
   const [performance, setPerformance] = useState(null);
+  const [error, setError] = useState(null);
 
   useEffect(() => {
-    getUserMainData(userId).then(setMainData);
-    getUserActivity(userId).then(setActivity);
-    getUserAverageSessions(userId).then(setAverage);
-    getUserPerformance(userId).then(setPerformance);
+    async function fetchData() {
+      try {
+        const [main, act, avg, perf] = await Promise.all([
+          getUserMainData(userId),
+          getUserActivity(userId),
+          getUserAverageSessions(userId),
+          getUserPerformance(userId),
+        ]);
+        setMainData(main);
+        setActivity(act);
+        setAverage(avg);
+        setPerformance(perf);
+      } catch (err) {
+        setError(err.message);
+      }
+    }
+    fetchData();
   }, []);
 
   const score = mainData?.todayScore ?? mainData?.score ?? 0;
+
+  if (error) {
+    return (
+      <div>
+        <Header />
+        <p>Error: {error}</p>
+      </div>
+    );
+  }
 
   return (
     <div>

--- a/my-react-app/src/services/userService.js
+++ b/my-react-app/src/services/userService.js
@@ -2,24 +2,36 @@ const API_URL = 'http://localhost:3000/user';
 
 export async function getUserMainData(id) {
   const res = await fetch(`${API_URL}/${id}`);
+  if (!res.ok) {
+    throw new Error('Failed to fetch user main data');
+  }
   const json = await res.json();
   return json.data;
 }
 
 export async function getUserActivity(id) {
   const res = await fetch(`${API_URL}/${id}/activity`);
+  if (!res.ok) {
+    throw new Error('Failed to fetch user activity');
+  }
   const json = await res.json();
   return json.data;
 }
 
 export async function getUserAverageSessions(id) {
   const res = await fetch(`${API_URL}/${id}/average-sessions`);
+  if (!res.ok) {
+    throw new Error('Failed to fetch user average sessions');
+  }
   const json = await res.json();
   return json.data;
 }
 
 export async function getUserPerformance(id) {
   const res = await fetch(`${API_URL}/${id}/performance`);
+  if (!res.ok) {
+    throw new Error('Failed to fetch user performance');
+  }
   const json = await res.json();
   return json.data;
 }


### PR DESCRIPTION
## Summary
- improve user service fetch calls by checking `res.ok`
- display an error if API requests fail in `UserProfile`

## Testing
- `npm --prefix my-react-app run lint`
- `npm --prefix my-react-app test`

------
https://chatgpt.com/codex/tasks/task_b_6871378f3b748331a7ab73fb5c3fce97