### PR TITLE
Map AverageSessions days to letters

### DIFF
--- a/my-react-app/src/components/AverageSessionsChart.jsx
+++ b/my-react-app/src/components/AverageSessionsChart.jsx
@@ -1,13 +1,28 @@
 import { ResponsiveContainer, LineChart, Line, XAxis, Tooltip } from 'recharts';
 
+const DAYS = ['L', 'M', 'M', 'J', 'V', 'S', 'D'];
+
 export default function AverageSessionsChart({ data }) {
   if (!data) return null;
   return (
     <ResponsiveContainer width="100%" height={200}>
-      <LineChart data={data.sessions} margin={{ top: 20, right: 20, left: 20, bottom: 5 }}>
-        <XAxis dataKey="day" tickLine={false} axisLine={false} />
+      <LineChart
+        data={data.sessions}
+        margin={{ top: 20, right: 20, left: 20, bottom: 5 }}
+      >
+        <XAxis
+          dataKey="day"
+          tickLine={false}
+          axisLine={false}
+          tickFormatter={(day) => DAYS[day - 1]}
+        />
         <Tooltip />
-        <Line type="monotone" dataKey="sessionLength" stroke="#fff" dot={false} />
+        <Line
+          type="monotone"
+          dataKey="sessionLength"
+          stroke="#fff"
+          dot={false}
+        />
       </LineChart>
     </ResponsiveContainer>
   );


### PR DESCRIPTION
## Summary
- map session day numbers to French initials in `AverageSessionsChart`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6871378ee7ec833195ba97ee4a174d62