### PR TITLE
Add routing-based user ID

### DIFF
--- a/my-react-app/package.json
+++ b/my-react-app/package.json
@@ -13,7 +13,8 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "axios": "^1.6.7",
-    "recharts": "^2.8.0"
+    "recharts": "^2.8.0",
+    "react-router-dom": "^6.23.0"
 
   },
   "devDependencies": {

--- a/my-react-app/src/App.jsx
+++ b/my-react-app/src/App.jsx
@@ -1,9 +1,11 @@
+import { Routes, Route, Navigate } from 'react-router-dom';
 import UserProfile from './components/UserProfile.jsx';
 
 export default function App() {
   return (
-    <div>
-      <UserProfile />
-    </div>
+    <Routes>
+      <Route path="/" element={<Navigate to="/user/12" replace />} />
+      <Route path="/user/:id" element={<UserProfile />} />
+    </Routes>
   );
 }

--- a/my-react-app/src/components/UserProfile.jsx
+++ b/my-react-app/src/components/UserProfile.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
 import Header from './Header.jsx';
 import ActivityChart from './ActivityChart.jsx';
 import AverageSessionsChart from './AverageSessionsChart.jsx';
@@ -12,8 +13,9 @@ import {
   getUserPerformance,
 } from '../services/userService.js';
 
-export default function UserProfile() {
-  const userId = 12;
+export default function UserProfile({ userId: propUserId }) {
+  const { id } = useParams();
+  const userId = propUserId ?? id;
   const [mainData, setMainData] = useState(null);
   const [activity, setActivity] = useState(null);
   const [average, setAverage] = useState(null);
@@ -21,6 +23,7 @@ export default function UserProfile() {
   const [error, setError] = useState(null);
 
   useEffect(() => {
+    if (!userId) return;
     async function fetchData() {
       try {
         const [main, act, avg, perf] = await Promise.all([
@@ -38,7 +41,7 @@ export default function UserProfile() {
       }
     }
     fetchData();
-  }, []);
+  }, [userId]);
 
   const score = mainData?.todayScore ?? mainData?.score ?? 0;
 

--- a/my-react-app/src/main.jsx
+++ b/my-react-app/src/main.jsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import './index.css'
 import App from './App.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- integrate `react-router-dom`
- grab `userId` from route params in `UserProfile`
- add routes `/` and `/user/:id`
- wrap app with router

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_68714f781b048331998a016d992d897c