### PR TITLE
Refactor profile layout to grid

### DIFF
--- a/my-react-app/src/components/UserProfile.css
+++ b/my-react-app/src/components/UserProfile.css
@@ -1,0 +1,13 @@
+.profile-grid {
+  display: grid;
+  grid-template-columns: 3fr 1fr;
+  column-gap: 2rem;
+}
+
+.main-content {
+  min-width: 300px;
+}
+
+.aside {
+  min-width: 200px;
+}

--- a/my-react-app/src/components/UserProfile.jsx
+++ b/my-react-app/src/components/UserProfile.jsx
@@ -5,6 +5,7 @@ import AverageSessionsChart from './AverageSessionsChart.jsx';
 import PerformanceRadarChart from './PerformanceRadarChart.jsx';
 import ScoreRadialChart from './ScoreRadialChart.jsx';
 import KeyDataCard, { KEY_INFO } from './KeyDataCard.jsx';
+import './UserProfile.css';
 import {
   getUserMainData,
   getUserActivity,
@@ -54,14 +55,14 @@ export default function UserProfile() {
   return (
     <div>
       <Header firstName={mainData?.userInfos?.firstName} />
-      <div style={{ display: 'flex', flexWrap: 'wrap' }}>
-        <div style={{ flex: '1 1 60%', minWidth: 300 }}>
+      <div className="profile-grid">
+        <div className="main-content">
           <ActivityChart data={activity} />
           <AverageSessionsChart data={average} />
           <PerformanceRadarChart data={performance} />
           <ScoreRadialChart value={score} />
         </div>
-        <div style={{ flex: '1 1 30%', minWidth: 200 }}>
+        <div className="aside">
           {mainData &&
             Object.entries(mainData.keyData || {}).map(([key, value]) => {
               const info = KEY_INFO[key] || { label: key, unit: '', icon: '' };


### PR DESCRIPTION
## Summary
- convert UserProfile layout to CSS Grid
- define profile layout styles in new `UserProfile.css`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_68714f774bd48331a57f9881bc1fdea7