### PR TITLE
Add sticky navigation header

### DIFF
--- a/my-react-app/src/components/Header.css
+++ b/my-react-app/src/components/Header.css
@@ -1,0 +1,19 @@
+.header {
+  padding: 1rem;
+  background: #222;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  position: sticky;
+  top: 0;
+  width: 100%;
+}
+
+.header nav ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  gap: 1rem;
+}

--- a/my-react-app/src/components/Header.jsx
+++ b/my-react-app/src/components/Header.jsx
@@ -1,9 +1,21 @@
+import './Header.css';
+
 export default function Header({ firstName }) {
   return (
-    <header style={{ padding: '1rem', background: '#222', color: '#fff' }}>
+    <header className="header">
       <h1>SportSee</h1>
-      <h2>Bonjour {firstName}</h2>
-      <p>Félicitation ! Vous avez explosé vos objectifs hier 👏</p>
+      <nav>
+        <ul>
+          <li>Accueil</li>
+          <li>Profil</li>
+          <li>Réglage</li>
+          <li>Communauté</li>
+        </ul>
+      </nav>
+      <div className="welcome">
+        <h2>Bonjour {firstName}</h2>
+        <p>Félicitation ! Vous avez explosé vos objectifs hier 👏</p>
+      </div>
     </header>
   );
 }


### PR DESCRIPTION
## Summary
- add nav links in `Header.jsx`
- move inline styles to `Header.css`
- make header sticky and arrange links in a horizontal flex layout

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6871504de4408331b545491d99562dd9