### PR TITLE
Fix padding and remove x-axis labels

### DIFF
--- a/my-react-app/src/components/ActivityChart.jsx
+++ b/my-react-app/src/components/ActivityChart.jsx
@@ -35,7 +35,7 @@ export default function ActivityChart({ data }) {
       style={{
         background: '#fff',
         fontFamily: 'Roboto, sans-serif',
-        padding: '1rem',
+        padding: '1rem 1rem 1rem 50px',
         maxWidth: '100%',
       }}
     >

--- a/my-react-app/src/components/AverageSessionsChart.jsx
+++ b/my-react-app/src/components/AverageSessionsChart.jsx
@@ -1,7 +1,5 @@
 import { ResponsiveContainer, LineChart, Line, XAxis, Tooltip } from 'recharts';
 
-const DAYS = ['L', 'M', 'M', 'J', 'V', 'S', 'D'];
-
 export default function AverageSessionsChart({ data }) {
   if (!data) return null;
   return (
@@ -14,7 +12,7 @@ export default function AverageSessionsChart({ data }) {
           dataKey="day"
           tickLine={false}
           axisLine={false}
-          tickFormatter={(day) => DAYS[day - 1]}
+          hide
         />
         <Tooltip />
         <Line


### PR DESCRIPTION
## Summary
- add left padding to activity chart container
- hide x-axis ticks under average sessions chart

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_6876433b2f58833190b3601e9289f53c