### PR TITLE
Restore router and sidebar usage

### DIFF
--- a/my-react-app/src/App.jsx
+++ b/my-react-app/src/App.jsx
@@ -1,25 +1,17 @@
-import KeyDataCard from './components/KeyDataCard.jsx';
+import { Routes, Route, Navigate } from 'react-router-dom';
+import Sidebar from './components/Sidebar.jsx';
+import UserProfile from './components/UserProfile.jsx';
 
 export default function App() {
-  const demoData = [
-    { label: 'Calories', value: 1930, unit: 'kCal', icon: '🔥', bgColor: '#FFE6E6' },
-    { label: 'Protéines', value: 155, unit: 'g', icon: '🍗', bgColor: '#E6F4FF' },
-    { label: 'Glucides', value: 290, unit: 'g', icon: '🍎', bgColor: '#FFF9DB' },
-    { label: 'Lipides', value: 50, unit: 'g', icon: '🍔', bgColor: '#FFEAF4' },
-  ];
-
   return (
-    <div className="demo-container">
-      {demoData.map((card) => (
-        <KeyDataCard
-          key={card.label}
-          label={card.label}
-          value={card.value}
-          unit={card.unit}
-          icon={card.icon}
-          bgColor={card.bgColor}
-        />
-      ))}
+    <div>
+      <Sidebar />
+      <div>
+        <Routes>
+          <Route path="/" element={<Navigate to="/user/12" replace />} />
+          <Route path="/user/:id" element={<UserProfile />} />
+        </Routes>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- reinstate router-based layout
- display `Sidebar` beside route contents

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_68765ffee4108331bac9bcca52a39194