### PR TITLE
Implement styled average session chart

### DIFF
--- a/my-react-app/src/components/AverageSessionsChart.css
+++ b/my-react-app/src/components/AverageSessionsChart.css
@@ -1,0 +1,52 @@
+.session-container {
+  background: linear-gradient(135deg, #ff4e4e, #ff2c2c);
+  border-radius: 25px;
+  padding: 30px;
+  margin: 30px auto;
+  width: 100%;
+  max-width: 600px;
+  box-shadow: 0 15px 35px rgba(0, 0, 0, 0.4);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 25px;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.session-container:hover {
+  transform: scale(1.02);
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.5);
+}
+
+.session-title {
+  font-size: 28px;
+  font-weight: 700;
+  color: #ffffff;
+  margin: 0;
+  text-align: center;
+  letter-spacing: 1px;
+}
+
+.session-chart {
+  width: 100%;
+  height: 350px;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 15px;
+  padding: 10px;
+}
+
+@media (max-width: 768px) {
+  .session-container {
+    padding: 20px;
+    border-radius: 20px;
+    gap: 20px;
+  }
+
+  .session-title {
+    font-size: 22px;
+  }
+
+  .session-chart {
+    height: 250px;
+  }
+}

--- a/my-react-app/src/components/AverageSessionsChart.jsx
+++ b/my-react-app/src/components/AverageSessionsChart.jsx
@@ -1,27 +1,35 @@
-import { ResponsiveContainer, LineChart, Line, XAxis, Tooltip } from 'recharts';
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  Tooltip,
+} from 'recharts';
+import './AverageSessionsChart.css';
 
 export default function AverageSessionsChart({ data }) {
   if (!data) return null;
   return (
-    <ResponsiveContainer width="100%" height={200}>
-      <LineChart
-        data={data.sessions}
-        margin={{ top: 20, right: 20, left: 20, bottom: 5 }}
-      >
-        <XAxis
-          dataKey="day"
-          tickLine={false}
-          axisLine={false}
-          hide
-        />
-        <Tooltip />
-        <Line
-          type="monotone"
-          dataKey="sessionLength"
-          stroke="#fff"
-          dot={false}
-        />
-      </LineChart>
-    </ResponsiveContainer>
+    <div className="session-container">
+      <h2 className="session-title">Durée moyenne des sessions</h2>
+      <div className="session-chart">
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart
+            data={data.sessions}
+            margin={{ top: 20, right: 20, left: 20, bottom: 5 }}
+          >
+            <XAxis dataKey="day" tickLine={false} axisLine={false} hide />
+            <Tooltip />
+            <Line
+              type="monotone"
+              dataKey="sessionLength"
+              stroke="#fff"
+              strokeWidth={2}
+              dot={false}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- enhance AverageSessionsChart with a styled container and title
- add matching CSS for red gradient layout

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_b_687666d38e848331a4c528dffdd5ead6