### PR TITLE
Add gradient and tooltip to sessions chart

### DIFF
--- a/my-react-app/src/components/AverageSessionsChart.css
+++ b/my-react-app/src/components/AverageSessionsChart.css
@@ -32,7 +32,15 @@
   height: 350px;
   background: rgba(255, 255, 255, 0.05);
   border-radius: 15px;
-  padding: 10px;
+  padding: 20px;
+}
+
+.session-tooltip {
+  background: #ffffff;
+  color: #000;
+  padding: 4px 8px;
+  font-size: 12px;
+  font-family: 'Roboto', sans-serif;
 }
 
 @media (max-width: 768px) {

--- a/my-react-app/src/components/AverageSessionsChart.jsx
+++ b/my-react-app/src/components/AverageSessionsChart.jsx
@@ -5,6 +5,19 @@ import {
   XAxis,
   Tooltip,
 } from 'recharts';
+
+const DAY_LETTERS = ['L', 'M', 'M', 'J', 'V', 'S', 'D'];
+
+function CustomTooltip({ active, payload }) {
+  if (active && payload && payload.length) {
+    return (
+      <div className="session-tooltip">
+        {payload[0].value} min
+      </div>
+    );
+  }
+  return null;
+}
 import './AverageSessionsChart.css';
 
 export default function AverageSessionsChart({ data }) {
@@ -16,14 +29,26 @@ export default function AverageSessionsChart({ data }) {
         <ResponsiveContainer width="100%" height="100%">
           <LineChart
             data={data.sessions}
-            margin={{ top: 20, right: 20, left: 20, bottom: 5 }}
+            margin={{ top: 40, right: 40, left: 40, bottom: 20 }}
           >
-            <XAxis dataKey="day" tickLine={false} axisLine={false} hide />
-            <Tooltip />
+            <defs>
+              <linearGradient id="sessionGradient" x1="0" y1="0" x2="1" y2="0">
+                <stop offset="0%" stopColor="rgba(255,255,255,0.4)" />
+                <stop offset="100%" stopColor="rgba(255,255,255,1)" />
+              </linearGradient>
+            </defs>
+            <XAxis
+              dataKey="day"
+              tickLine={false}
+              axisLine={false}
+              tick={{ fill: '#fff', opacity: 0.6, fontSize: 12 }}
+              tickFormatter={(day) => DAY_LETTERS[day - 1]}
+            />
+            <Tooltip content={<CustomTooltip />} />
             <Line
               type="monotone"
               dataKey="sessionLength"
-              stroke="#fff"
+              stroke="url(#sessionGradient)"
               strokeWidth={2}
               dot={false}
             />


### PR DESCRIPTION
## Summary
- show weekdays using tickFormatter rather than hiding axis
- add gradient line stroke and custom tooltip
- enlarge chart margins and padding

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_68766f5099708331924d75ddb2a8d929