### PR TITLE
Fix radial chart prop usage

### DIFF
--- a/my-react-app/src/components/UserProfile.jsx
+++ b/my-react-app/src/components/UserProfile.jsx
@@ -44,8 +44,6 @@ export default function UserProfile({ userId: propUserId }) {
     fetchData();
   }, [userId]);
 
-  const score = mainData?.todayScore ?? mainData?.score ?? 0;
-
   if (error) {
     return (
       <div>
@@ -74,9 +72,11 @@ export default function UserProfile({ userId: propUserId }) {
           <div className="chart-container">
             <PerformanceRadarChart data={performance} />
           </div>
-          <div className="chart-container">
-            <ScoreRadialChart value={score} />
-          </div>
+          {mainData && (
+            <div className="chart-container">
+              <ScoreRadialChart data={mainData} />
+            </div>
+          )}
         </div>
         <aside className="dashboard-aside">
           {mainData &&


### PR DESCRIPTION
## Summary
- pass user data to `ScoreRadialChart` instead of computed value
- only render the radial chart when `mainData` is loaded
- remove unused `score` constant

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_68767c89fa08833197f37e00a88c8b52