### PR TITLE
Adjust dashboard layout and remove chart margins

### DIFF
--- a/my-react-app/src/components/ActivityChart.css
+++ b/my-react-app/src/components/ActivityChart.css
@@ -3,7 +3,6 @@
   font-family: 'Roboto', sans-serif;
   padding: 1rem 1rem 1rem 50px;
   max-width: 100%;
-  margin-left: 50px;
 }
 
 .activity-chart-title {

--- a/my-react-app/src/components/AverageSessionsChart.css
+++ b/my-react-app/src/components/AverageSessionsChart.css
@@ -10,8 +10,6 @@
   justify-content: center;
   position: relative;
   overflow: hidden;
-  margin-left: 60px;
-  /* ✅ espace à gauche */
 }
 
 .session-title {

--- a/my-react-app/src/components/PerformanceRadarChart.css
+++ b/my-react-app/src/components/PerformanceRadarChart.css
@@ -7,7 +7,6 @@
     display: flex;
     justify-content: center;
     align-items: center;
-    margin-left: 60px;
 }
 
 .recharts-polar-grid-polygon {

--- a/my-react-app/src/components/ScoreRadialChart.css
+++ b/my-react-app/src/components/ScoreRadialChart.css
@@ -10,7 +10,6 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    margin-left: 60px;
 }
 
 .score-title {

--- a/my-react-app/src/components/UserProfile.css
+++ b/my-react-app/src/components/UserProfile.css
@@ -18,7 +18,15 @@
 }
 
 .dashboard-main {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: auto 1fr;
+  gap: 2rem;
   min-width: 300px;
+}
+
+.dashboard-main .chart-container:first-child {
+  grid-column: 1 / -1;
 }
 
 .dashboard-aside {


### PR DESCRIPTION
## Summary
- use grid layout for dashboard charts
- span first chart across full width
- remove chart container left margins

## Testing
- `npm run lint --prefix my-react-app` *(fails: Cannot find package '@eslint/js')*
- `npm install --prefix my-react-app` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_b_68775d0ae61483319458b52a7ff8ac2f